### PR TITLE
remove gstAndroidRoot path

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,3 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-gstAndroidRoot=/Users/justin/Library/Android/gstreamer/1.12.1


### PR DESCRIPTION
Remove defined gstAndroidRoot path in gradle.properties as it overrides the path set in an environment variable and leads to compiling errors, because the gstreamer android binaries are not found.