### PR TITLE
Comment out gstAndroidRoot path

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,7 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-gstAndroidRoot=/Users/justin/Library/Android/gstreamer/1.12.1
+
+
+# example path usage
+# gstAndroidRoot=/Users/justin/Library/Android/gstreamer/1.12.1


### PR DESCRIPTION
Comment out gstAndroidRoot path definition in gradle.properties to avoid compiling errors, as the correct gstreamer android binaries are not found.